### PR TITLE
Support for CORS requests

### DIFF
--- a/server.py
+++ b/server.py
@@ -141,15 +141,34 @@ def handle_range_request(environ):
     return status, response_headers, response_body
 
 
+def handle_options_request(environ):
+    '''Assume this is in response to a CORS preflight request.'''
+    return status_code_response(200), [
+        ('Access-Control-Allow-Methods', 'HEAD, GET, OPTIONS'),
+        ('Content-Type', 'text/plain'),
+        ('Content-Length', '0')], ''
+
+
+def add_cors_headers(environ, headers):
+    '''Add headers which allow arbitrary cross-origin requests.'''
+    if 'HTTP_ORIGIN' not in environ:
+        return  # not a CORS request
+    headers.extend([('Access-Control-Allow-Origin', '*'),
+                    ('Access-Control-Allow-Headers', 'Range')])
+
+
 def application(environ, start_response):
     '''Required WSGI interface.'''
     request_method = environ['REQUEST_METHOD']
 
-    if request_method not in ['GET', 'HEAD']:
+    if request_method not in ['GET', 'HEAD', 'OPTIONS']:
         response_body = 'Method %s not allowed.' % request_method
         start_response(status_code_response(405),
                        make_response_headers(response_body))
         return [response_body]
+
+    if request_method == 'OPTIONS':
+        status, response_headers, response_body = handle_options_request(environ)
 
     byte_range_header = environ.get('HTTP_RANGE')
     if byte_range_header:
@@ -161,6 +180,7 @@ def application(environ, start_response):
         elif request_method == 'HEAD':
             status, response_headers, response_body = handle_head_request(path)
 
+    add_cors_headers(environ, response_headers)
     start_response(status, response_headers)
 
     return [response_body]


### PR DESCRIPTION
Biodalliance can stream data over HTTP if the server supports CORS.

To see this in action, head over to [biodalliance](http://www.biodalliance.org/human37.html), click "+" and add `http://hammerlab-dev3.hpc.mssm.edu:9876/datasets/dream/data/training/normal.chr20.withMDTags.bam`.

See [this article](https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS) for details on CORS.
