### PR TITLE
RangeHTTPServer

### DIFF
--- a/RangeHTTPServer.py
+++ b/RangeHTTPServer.py
@@ -1,0 +1,76 @@
+#!/usr/bin/python
+'''
+Use this in the same way as Python's SimpleHTTPServer:
+
+  python -m RangeHTTPServer [port]
+
+The only difference from SimpleHTTPServer is that RangeHTTPServer supports
+'Range:' headers to load portions of files. This is helpful for doing local web
+development with genomic data files, which tend to be to large to load into the
+browser all at once.
+'''
+
+import os
+import sys
+from SimpleHTTPServer import SimpleHTTPRequestHandler
+import SimpleHTTPServer
+
+import server
+
+
+def copy_byte_range(infile, outfile, start, stop=None, bufsize=16*1024):
+    '''Like shutil.copyfileobj, but only copy a range of the streams.'''
+    infile.seek(start)
+    while 1:
+        to_read = min(bufsize, stop - infile.tell() if stop else bufsize)
+        buf = infile.read(to_read)
+        if not buf:
+            break
+        outfile.write(buf)
+
+
+class RangeRequestHandler(SimpleHTTPRequestHandler):
+    """Adds support for HTTP 'Range' requests to SimpleHTTPRequestHandler
+
+    The approach is to:
+    - Override send_head to look for 'Range' and respond appropriately.
+    - Override copyfile to only transmit a range when requested.
+    """
+    def send_head(self):
+        if 'Range' not in self.headers:
+            self.range = None
+            return SimpleHTTPRequestHandler.send_head(self)
+        self.range = server.parse_byte_range(self.headers['Range'])
+        first, last = self.range
+  
+        # Mirroring SimpleHTTPServer.py here
+        path = self.translate_path(self.path)
+        f = None
+        ctype = self.guess_type(path)
+        try:
+            f = open(path, 'rb')
+        except IOError:
+            self.send_error(404, 'File not found')
+            return None
+        self.send_response(206)
+        self.send_header('Content-type', ctype)
+        fs = os.fstat(f.fileno())
+        self.send_header('Accept-Ranges', 'bytes')
+        self.send_header('Content-Range', 'bytes %s-%s/%s' % (first, last, fs[6]))
+        self.send_header('Content-Length', str(last - first))
+        self.send_header('Last-Modified', self.date_time_string(fs.st_mtime))
+        self.end_headers()
+        return f
+
+    def copyfile(self, source, outputfile):
+        if not self.range:
+            return SimpleHTTPRequestHandler.copyfile(self, source, outputfile)
+
+        # SimpleHTTPRequestHandler uses shutil.copyfileobj, which doesn't let
+        # you stop the copying before the end of the file.
+        start, stop = self.range
+        copy_byte_range(source, outputfile, start, stop)
+
+
+if __name__ == '__main__':
+    SimpleHTTPServer.test(HandlerClass=RangeRequestHandler)

--- a/RangeHTTPServer.py
+++ b/RangeHTTPServer.py
@@ -19,10 +19,13 @@ import server
 
 
 def copy_byte_range(infile, outfile, start, stop=None, bufsize=16*1024):
-    '''Like shutil.copyfileobj, but only copy a range of the streams.'''
+    '''Like shutil.copyfileobj, but only copy a range of the streams.
+
+    Both start and stop are inclusive.
+    '''
     infile.seek(start)
     while 1:
-        to_read = min(bufsize, stop - infile.tell() if stop else bufsize)
+        to_read = min(bufsize, stop + 1 - infile.tell() if stop else bufsize)
         buf = infile.read(to_read)
         if not buf:
             break
@@ -57,7 +60,7 @@ class RangeRequestHandler(SimpleHTTPRequestHandler):
         fs = os.fstat(f.fileno())
         self.send_header('Accept-Ranges', 'bytes')
         self.send_header('Content-Range', 'bytes %s-%s/%s' % (first, last, fs[6]))
-        self.send_header('Content-Length', str(last - first))
+        self.send_header('Content-Length', str(last - first + 1))
         self.send_header('Last-Modified', self.date_time_string(fs.st_mtime))
         self.end_headers()
         return f

--- a/tests/RangeHTTPServer_test.py
+++ b/tests/RangeHTTPServer_test.py
@@ -1,0 +1,19 @@
+import RangeHTTPServer
+
+from nose.tools import *
+from StringIO import StringIO
+
+def test_copy_byte_range():
+    inbuffer = StringIO('0123456789abcdefghijklmnopqrstuvwxyz')
+    outbuffer = StringIO()
+
+    RangeHTTPServer.copy_byte_range(inbuffer, outbuffer, 4, 10)
+    eq_('456789', outbuffer.getvalue())
+
+    outbuffer = StringIO()
+    RangeHTTPServer.copy_byte_range(inbuffer, outbuffer, 0, 4)
+    eq_('0123', outbuffer.getvalue())
+
+    outbuffer = StringIO()
+    RangeHTTPServer.copy_byte_range(inbuffer, outbuffer, 26)
+    eq_('qrstuvwxyz', outbuffer.getvalue())

--- a/tests/RangeHTTPServer_test.py
+++ b/tests/RangeHTTPServer_test.py
@@ -8,12 +8,16 @@ def test_copy_byte_range():
     outbuffer = StringIO()
 
     RangeHTTPServer.copy_byte_range(inbuffer, outbuffer, 4, 10)
-    eq_('456789', outbuffer.getvalue())
+    eq_('456789a', outbuffer.getvalue())
 
     outbuffer = StringIO()
     RangeHTTPServer.copy_byte_range(inbuffer, outbuffer, 0, 4)
-    eq_('0123', outbuffer.getvalue())
+    eq_('01234', outbuffer.getvalue())
 
     outbuffer = StringIO()
     RangeHTTPServer.copy_byte_range(inbuffer, outbuffer, 26)
     eq_('qrstuvwxyz', outbuffer.getvalue())
+
+    outbuffer = StringIO()
+    RangeHTTPServer.copy_byte_range(inbuffer, outbuffer, 0, 9, 10)
+    eq_('0123456789', outbuffer.getvalue())


### PR DESCRIPTION
This is an add-on which acts as a drop-in replacement for Python's `SimpleHTTPServer` which supports `Range` requests.

Usage:

```
python -m RangeHTTPServer
```

This is really helpful for iterating locally on browser-based genome viewers.
